### PR TITLE
Add alias for server restart

### DIFF
--- a/symfony.plugin.zsh
+++ b/symfony.plugin.zsh
@@ -5,7 +5,7 @@ alias sfnew='symfony new';
 alias sfstart='sf server:start';
 alias sfrun='sf server:run -vvv';
 alias sfstop='sf server:stop';
-alias sfstop='sf server:stop; sleep 0.5; sf server:start';
+alias sfrestart='sf server:stop; sleep 0.5; sf server:start';
 alias encore-watch='encore dev --watch'
 
 sf() {

--- a/symfony.plugin.zsh
+++ b/symfony.plugin.zsh
@@ -5,6 +5,7 @@ alias sfnew='symfony new';
 alias sfstart='sf server:start';
 alias sfrun='sf server:run -vvv';
 alias sfstop='sf server:stop';
+alias sfstop='sf server:stop; sleep 0.5; sf server:start';
 alias encore-watch='encore dev --watch'
 
 sf() {


### PR DESCRIPTION
Sometimes Symfony dev server hangs and it is necessary to restart it. 
"sleep" is needed to ensure that the port would be default one on each launch - without it ports cycle between 8000 and 8001 (seems to be related to the amount of time needed to delete .web-server-pid file).